### PR TITLE
Silent when OPEN_SOURCE_SUPPORTER=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,11 @@ The funds raised so far ($2,000) have paid for Feross's time to [release Standar
 ## Where can I provide feedback about this experiment?
 
 You can open an issue. But please be kind. I'm a human with feelings. ❤️
+
+## How can I disable this?
+
+Just to be super clear: **This package does no tracking or data collecting — and it will always stay this way.** It's just a fancy `console.log()`.
+
+If you support open source through direct contributions, donations, or however else you see fit, you can permanently silence `funding` by adding an environment variable `OPEN_SOURCE_SUPPORTER=true` to your terminal environment.
+
+Note, `funding` also respects npm's `loglevel` setting, so e.g. `npm install --silent` and `npm install --quiet` will be respected.

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -7,7 +7,8 @@ const ciInfo = require('ci-info')
 
 const {
   TERM_PROGRAM,
-  npm_config_loglevel: NPM_CONFIG_LOGLEVEL
+  npm_config_loglevel: NPM_CONFIG_LOGLEVEL,
+  OPEN_SOURCE_SUPPORTER
 } = process.env
 
 // Is Hyper (Mac)?
@@ -25,8 +26,13 @@ const isCI = () => ciInfo.isCI
 // Is silent mode enabled?
 const isSilentMode = () => (
   ['silent', 'error'].includes(NPM_CONFIG_LOGLEVEL) ||
-  (NPM_CONFIG_LOGLEVEL === 'warn' && !process.version.startsWith('v6.'))
+  (NPM_CONFIG_LOGLEVEL === 'warn' && !process.version.startsWith('v6.')) ||
+  isEnabled(OPEN_SOURCE_SUPPORTER)
 )
+
+function isEnabled (value) {
+  return !!value && value !== '0' && value !== 'false'
+}
 
 module.exports = {
   isHyper,

--- a/test/funding.js
+++ b/test/funding.js
@@ -95,6 +95,7 @@ test('deduplication / rate-limiting', t => {
       t.equal(stdout, '', 'no stdout ouput')
       t.equal(stderr, '', 'no stderr output')
     })
+  })
 })
 
 test('OPEN_SOURCE_SUPPORTER=true prevents output', t => {

--- a/test/funding.js
+++ b/test/funding.js
@@ -78,7 +78,7 @@ test('`npm --loglevel error` prevents output', t => {
   })
 })
 
-test('`npm --loglevel error` prevents output', t => {
+test('deduplication / rate-limiting', t => {
   t.plan(7)
 
   clearShown()
@@ -95,5 +95,20 @@ test('`npm --loglevel error` prevents output', t => {
       t.equal(stdout, '', 'no stdout ouput')
       t.equal(stderr, '', 'no stderr output')
     })
+})
+
+test('OPEN_SOURCE_SUPPORTER=true prevents output', t => {
+  t.plan(3)
+
+  const opts = {
+    env: Object.assign({}, process.env, {
+      OPEN_SOURCE_SUPPORTER: 'true'
+    })
+  }
+
+  cp.execFile(FUNDING_BIN_PATH, [], opts, (err, stdout, stderr) => {
+    t.error(err)
+    t.equal(stdout.length, 0, 'no stdout ouput')
+    t.equal(stderr.length, 0, 'no stderr output')
   })
 })


### PR DESCRIPTION
Just to be super clear: **This package does no tracking or data collecting — and it will always stay this way.** It's just a fancy `console.log()`.

If you support open source through direct contributions, donations, or however else you see fit, you can permanently silence `funding` by adding an environment variable `OPEN_SOURCE_SUPPORTER=true` to your terminal environment.

Note: `funding` also respects npm's `loglevel` setting, so e.g. `npm install --silent` and `npm install --quiet` will be respected.

Also, `funding` will only ever print one message, even if (for some reason) it appears in the dependency tree multiple times.